### PR TITLE
feat(config): allow usage of env vars to set config

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,43 +1,50 @@
 ---
 server:
-  port: 9002
+  port: ${SERVER_PORT:9002}
 logging:
   level:
     org:
       apache:
         coyote:
           http11: WARN
+
 spring:
   jackson:
     property-naming-strategy: SNAKE_CASE
     default-property-inclusion: non_null
-context:
-  domain: nic2004:52110
-  city: std:080
-  country: IND
-  bap_id: box.beckn.org
-  bap_uri: http://qa.api.box.beckn.org/bap/v1
-  ttl_seconds: 20
+
 database:
   mongo:
-    url: mongodb://localhost:27017
-    name: sandbox_bap
+    url: ${DATABASE_URL:mongodb://localhost:27017}
+    name: ${DATABASE_NAME:bap}
+
+registry_service:
+  url: ${REGISTRY_URL:https://demo4460370.mockable.io/registry/}
+  retry:
+    max_attempts: ${REGISTRY_RETRY_MAX_ATTEMPTS:3}
+    initial_interval_in_millis: ${REGISTRY_RETRY_INTERVAL:1000}
+    interval_multiplier: ${REGISTRY_RETRY_INTERVAL_MULTIPLIER:1.0}
+bpp_registry_service:
+  url: ${BPP_URL:https://demo4460370.mockable.io/bpp_registry/}
+
+context:
+  domain: ${BAP_DOMAIN:nic2004:52110}
+  city: ${BAP_CITY_CODE:std:080}
+  country: ${BAP_COUNTRY_CODE:IND}
+  bap_id: ${BAP_ID:box.beckn.org}
+  bap_uri: ${BAP_URL:http://localhost:9002/protocol/v1}
+  ttl_seconds: ${BAP_TTL:20}
+
 beckn:
-  security.enabled: false
+  security.enabled: ${BECKN_SECURITY_ENABLED:false}
 security:
   self:
-    private_key:
-    unique_key_id: key1
-registry_service:
-  url: https://demo4460370.mockable.io/registry/
-  retry:
-    max_attempts: 3
-    initial_interval_in_millis: 1000
-    interval_multiplier: 1.0
-bpp_registry_service:
-  url: https://demo4460370.mockable.io/bpp_registry/
+    private_key: ${BAP_PRIVATE_KEY:some-key}
+    unique_key_id: ${BAP_KEY_ID:default-key}
+
 management:
   endpoints:
     web:
       exposure:
-        include: "configprops, env, health, loggers, metrics, mappings, httptrace"
+        include:
+          'configprops, env, health, loggers, metrics, mappings, httptrace'


### PR DESCRIPTION
This means we can change configuration by environment variables at runtime.

An example with docker:

```
docker run ghcr.io/beckn/bap-protocol-helper --env DATABASE_URL=mongdb://localhost:27017
```
