### PR TITLE
fix(version): use the latest version of `protocol-dtos`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ dependencies {
   implementation("io.arrow-kt:arrow-optics:0.13.2")
   implementation("org.litote.kmongo:kmongo:4.2.8")
   implementation("org.mapstruct:mapstruct:1.4.2.Final")
-  implementation("org.beckn.jvm:beckn-protocol-dtos:0.9.3.20")
+  implementation("org.beckn.jvm:beckn-protocol-dtos:0.9.3.+")
   implementation("org.bouncycastle:bcprov-jdk15on:1.69")
   implementation("commons-codec:commons-codec:1.15")
   implementation("com.squareup.retrofit2:retrofit:$retrofitVersion")


### PR DESCRIPTION
From the discussion on slack: https://beckn.slack.com/archives/C031MGWP20G/p1644230583921789?thread_ts=1644218807.983229&cid=C031MGWP20G

I read a bit more on the shipkit autoversion plugin and realised that the problem is not that the version number in `version.properties` (in the `protocol-dtos` library) is not bumped.

The problem lies in the fact that the `protocol-dtos` library follows the rolling release model (every new commit to `main` is a new release), however, the `client` and `protocol-helper` both are stuck on an older version that cannot be built from the latest sources.

My proposed solution is to change the `client` and `protocol-helper` repos to accept v0.9.3.* of the protocol-dtos library, so that the latest release compatible with the Beckn Protocol v0.9.3 is always used.

---

Fixes #15 